### PR TITLE
Add JavascriptChannel abstraction in dart code

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -9,7 +9,14 @@ const kAndroidUserAgent =
 
 String selectedUrl = 'https://damp-coast-35782.herokuapp.com';
 
-const List<String> jsChannels = ['Print'];
+// ignore: prefer_collection_literals
+final Set<JavascriptChannel> jsChannels = [
+  JavascriptChannel(
+      name: 'Print',
+      onMessageReceived: (JavascriptMessage message) {
+        print(message.message);
+      }),
+].toSet();
 
 void main() => runApp(MyApp());
 
@@ -102,8 +109,6 @@ class _MyHomePageState extends State<MyHomePage> {
 
   StreamSubscription<double> _onScrollXChanged;
 
-  StreamSubscription<JavascriptMessage> _onPostMessage;
-
   final _urlCtrl = TextEditingController(text: selectedUrl);
 
   final _codeCtrl = TextEditingController(text: 'window.navigator.userAgent');
@@ -184,15 +189,6 @@ class _MyHomePageState extends State<MyHomePage> {
         });
       }
     });
-
-    _onPostMessage =
-        flutterWebViewPlugin.onPostMessage.listen((JavascriptMessage message) {
-      if (mounted) {
-        setState(() {
-          _history.add('onPostMessage: ${message.channel} ${message.message}');
-        });
-      }
-    });
   }
 
   @override
@@ -205,7 +201,6 @@ class _MyHomePageState extends State<MyHomePage> {
     _onProgressChanged.cancel();
     _onScrollXChanged.cancel();
     _onScrollYChanged.cancel();
-    _onPostMessage.cancel();
 
     flutterWebViewPlugin.dispose();
 

--- a/lib/flutter_webview_plugin.dart
+++ b/lib/flutter_webview_plugin.dart
@@ -1,5 +1,6 @@
 library flutter_webview_plugin;
 
 export 'src/base.dart';
+export 'src/javascript_channel.dart';
 export 'src/javascript_message.dart';
 export 'src/webview_scaffold.dart';

--- a/lib/src/javascript_channel.dart
+++ b/lib/src/javascript_channel.dart
@@ -1,0 +1,36 @@
+import 'package:meta/meta.dart';
+import 'package:flutter_webview_plugin/flutter_webview_plugin.dart';
+
+final RegExp _validChannelNames = RegExp('^[a-zA-Z_][a-zA-Z0-9]*\$');
+
+/// A named channel for receiving messaged from JavaScript code running inside a web view.
+class JavascriptChannel {
+  /// Constructs a Javascript channel.
+  ///
+  /// The parameters `name` and `onMessageReceived` must not be null.
+  JavascriptChannel({
+    @required this.name,
+    @required this.onMessageReceived,
+  })  : assert(name != null),
+        assert(onMessageReceived != null),
+        assert(_validChannelNames.hasMatch(name));
+
+  /// The channel's name.
+  ///
+  /// Passing this channel object as part of a [WebView.javascriptChannels] adds a channel object to
+  /// the Javascript window object's property named `name`.
+  ///
+  /// The name must start with a letter or underscore(_), followed by any combination of those
+  /// characters plus digits.
+  ///
+  /// Note that any JavaScript existing `window` property with this name will be overriden.
+  ///
+  /// See also [WebView.javascriptChannels] for more details on the channel registration mechanism.
+  final String name;
+
+  /// A callback that's invoked when a message is received through the channel.
+  final JavascriptMessageHandler onMessageReceived;
+}
+
+/// Callback type for handling messages sent from Javascript running in a web view.
+typedef void JavascriptMessageHandler(JavascriptMessage message);

--- a/lib/src/javascript_message.dart
+++ b/lib/src/javascript_message.dart
@@ -3,13 +3,8 @@
 class JavascriptMessage {
   /// Constructs a JavaScript message object.
   ///
-  /// The `channel` parameter must not be null.
   /// The `message` parameter must not be null.
-  const JavascriptMessage(this.channel, this.message)
-      : assert(message != null, channel != null);
-
-  /// The contents of the channel that was sent by the JavaScript code.
-  final String channel;
+  const JavascriptMessage(this.message) : assert(message != null);
 
   /// The contents of the message that was sent by the JavaScript code.
   final String message;

--- a/lib/src/webview_scaffold.dart
+++ b/lib/src/webview_scaffold.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter_webview_plugin/src/javascript_channel.dart';
 
 import 'base.dart';
 
@@ -42,7 +43,7 @@ class WebviewScaffold extends StatefulWidget {
   final PreferredSizeWidget appBar;
   final String url;
   final Map<String, String> headers;
-  final List<String> javascriptChannels;
+  final Set<JavascriptChannel> javascriptChannels;
   final bool withJavascript;
   final bool clearCache;
   final bool clearCookies;
@@ -86,7 +87,9 @@ class _WebviewScaffoldState extends State<WebviewScaffold> {
     webviewReference.close();
 
     _onBack = webviewReference.onBack.listen((_) async {
-      if (!mounted) return;
+      if (!mounted) {
+        return;
+      }
 
       // The willPop/pop pair here is equivalent to Navigator.maybePop(),
       // which is what's called from the flutter back button handler.
@@ -147,7 +150,7 @@ class _WebviewScaffoldState extends State<WebviewScaffold> {
             webviewReference.launch(
               widget.url,
               headers: widget.headers,
-              javascriptChannelNames: widget.javascriptChannels,
+              javascriptChannels: widget.javascriptChannels,
               withJavascript: widget.withJavascript,
               clearCache: widget.clearCache,
               clearCookies: widget.clearCookies,


### PR DESCRIPTION
Create JavaScript Channel abstraction in dart part in order to avoid the switch case needed otherwise when listening for messages.